### PR TITLE
fix for null values in the settings

### DIFF
--- a/ideal-image-slider.js
+++ b/ideal-image-slider.js
@@ -22,7 +22,7 @@ var IdealImageSlider = (function() {
 				continue;
 			for(var key in obj){
 				if(obj.hasOwnProperty(key)){
-					if(typeof obj[key] === 'object')
+					if(typeof obj[key] === 'object' && obj[key] !== null)
 						deepExtend(out[key], obj[key]);
 					else
 						out[key] = obj[key];


### PR DESCRIPTION
I am using my container's CSS height so I don't want the settings.height value.

To achieve this effect you need to pass in "height: null" in the settings because otherwise the code will override the container's height when it sees a non-null value in the settings. So passing "height: null" in the settings will fix the issue. To make that work, need to fix this little issue with deepExtend. 

p.s. I originally fixed the problem in a slightly different way by initializing the default settings.height to null and then, if the container's own css height was not set, and no settings.height was provided by the client, then I supplied a default value of 400px. Both methods fix the problem equally well, but PR here was the smallest possible change.
